### PR TITLE
Support multi-arch build for edgeapp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,6 @@
 
 FROM ubuntu:24.04
 
-ARG EXTRA_CFLAGS
-
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
        --no-install-recommends \
@@ -23,25 +21,28 @@ RUN apt-get update \
        wget \
        ca-certificates \
        cmake \
-       git \
-       clang \
-       llvm \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Detect architecture and download appropriate wasi-sdk
 RUN cd /opt \
-    && wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-22/wasi-sdk-22.0-linux.tar.gz \
-    && tar zxvf wasi-sdk-22.0-linux.tar.gz \
-    && ln -s wasi-sdk-22.0 wasi-sdk \
-    && rm wasi-sdk-22.0-linux.tar.gz
+    && ARCH=$(uname -m) \
+    && if [ "$ARCH" = "x86_64" ]; then \
+         WASI_ARCH="x86_64"; \
+       elif [ "$ARCH" = "aarch64" ]; then \
+         WASI_ARCH="arm64"; \
+       else \
+         echo "Unsupported architecture: $ARCH" && exit 1; \
+       fi \
+    && wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-24/wasi-sdk-24.0-${WASI_ARCH}-linux.tar.gz \
+    && tar zxvf wasi-sdk-24.0-${WASI_ARCH}-linux.tar.gz \
+    && ln -s wasi-sdk-24.0-${WASI_ARCH}-linux wasi-sdk \
+    && rm wasi-sdk-24.0-${WASI_ARCH}-linux.tar.gz
 
-RUN test ${EXTRA_CFLAGS} = '-g' && git clone https://github.com/WebAssembly/wasi-libc.git -b wasi-sdk-22 && \
-    cd wasi-libc && \
-    make EXTRA_CFLAGS=${EXTRA_CFLAGS} THREAD_MODEL=posix SYSROOT=/opt/wasi-sdk/share/wasi-sysroot install || \
-    echo "skip building with ${EXTRA_CFLAGS}"
-
+# Detect architecture and download appropriate binaryen
 RUN cd /opt \
-    && wget https://github.com/WebAssembly/binaryen/releases/download/version_117/binaryen-version_117-x86_64-linux.tar.gz \
-    && tar zxvf binaryen-version_117-x86_64-linux.tar.gz \
+    && ARCH=$(uname -m) \
+    && wget https://github.com/WebAssembly/binaryen/releases/download/version_117/binaryen-version_117-${ARCH}-linux.tar.gz \
+    && tar zxvf binaryen-version_117-${ARCH}-linux.tar.gz \
     && ln -s binaryen-version_117 binaryen \
-    && rm binaryen-version_117-x86_64-linux.tar.gz
+    && rm binaryen-version_117-${ARCH}-linux.tar.gz


### PR DESCRIPTION
By supporting multi-arch, we can build the wasm even inside the device